### PR TITLE
fix(ci): generate GitHub App token in generate_snapshot job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,6 +518,7 @@ jobs:
           files: scripts/snapshot-comment.md
           search: '{VERSION}'
           replace: $SNAPSHOT_VERSION
+      - generate_luciq_github_app_token
       - notify_github:
           data: "$(jq -Rcs '{ body: . }' scripts/snapshot-comment.md)"
 

--- a/scripts/notify-github.sh
+++ b/scripts/notify-github.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 
+set -euo pipefail
+
 pr_url="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open"
 pr_response=$(curl --location --request GET "$pr_url" --header "Authorization: Bearer $RELEASE_GITHUB_TOKEN")
 
-if [ $(echo "$pr_response" | jq length) -eq 0 ]; then
-  echo "No PR found to update"
-else
-  pr_comment_url=$(echo "$pr_response" | jq -r ".[]._links.comments.href")
-
-  curl --location --request POST "$pr_comment_url" \
-    --header 'Content-Type: application/json' \
-    --header "Authorization: Bearer $RELEASE_GITHUB_TOKEN" \
-    --data-raw "$1"
+if ! echo "$pr_response" | jq -e 'type == "array"' >/dev/null; then
+  echo "Unexpected GitHub API response (not an array):"
+  echo "$pr_response"
+  exit 1
 fi
+
+if [ "$(echo "$pr_response" | jq length)" -eq 0 ]; then
+  echo "No PR found to update"
+  exit 0
+fi
+
+pr_comment_url=$(echo "$pr_response" | jq -r ".[]._links.comments.href")
+
+curl --location --request POST "$pr_comment_url" \
+  --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $RELEASE_GITHUB_TOKEN" \
+  --data-raw "$1"


### PR DESCRIPTION
## Summary

- Fix: invoke `generate_luciq_github_app_token` in the `generate_snapshot` job before `notify_github`, mirroring how `danger` and `publish` already do it.
- Defense-in-depth: harden `scripts/notify-github.sh` with `set -euo pipefail` and an explicit `type == "array"` check on the GitHub API response, so any future auth failure, rate limit, or 404 exits cleanly with the response printed instead of producing the confusing two-tool error chain.
