### PR TITLE
feat: [MOB-22462] add LuciqErrorBoundary component

### DIFF
--- a/src/components/LuciqErrorBoundary.tsx
+++ b/src/components/LuciqErrorBoundary.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { ErrorInfo, ReactNode } from 'react';
+
+import * as BugReporting from '../modules/BugReporting';
+import * as CrashReporting from '../modules/CrashReporting';
+import type { NonFatalOptions } from '../models/NonFatalOptions';
+import { InvocationOption, ReportType } from '../utils/Enums';
+import { Logger } from '../utils/logger';
+
+export interface LuciqErrorBoundaryFallbackProps {
+  /**
+   * The error that was caught during rendering.
+   */
+  error: Error;
+  /**
+   * The React component stack trace where the error originated.
+   */
+  componentStack: string | null;
+  /**
+   * Resets the error boundary state and re-renders the children.
+   */
+  resetError: () => void;
+}
+
+export interface LuciqErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * A custom component rendered when a render error is caught. Receives the
+   * error, the component stack trace, and a `resetError` callback.
+   */
+  FallbackComponent?: React.ComponentType<LuciqErrorBoundaryFallbackProps>;
+  /**
+   * Called after the error is reported to Luciq. Use it for custom side
+   * effects such as logging or navigation.
+   */
+  onError?: (error: Error, componentStack: string | null) => void;
+  /**
+   * When `true`, the bug reporting UI is shown automatically once a render
+   * error is caught. Defaults to `false`.
+   */
+  showBugReporting?: boolean;
+  /**
+   * Extra configuration forwarded to `CrashReporting.reportError`.
+   */
+  nonFatalOptions?: NonFatalOptions;
+}
+
+interface LuciqErrorBoundaryState {
+  error: Error | null;
+  componentStack: string | null;
+}
+
+/**
+ * A React error boundary that catches rendering errors, reports them to Luciq
+ * as non-fatal crashes, and optionally renders a fallback UI.
+ */
+export class LuciqErrorBoundary extends React.Component<
+  LuciqErrorBoundaryProps,
+  LuciqErrorBoundaryState
+> {
+  state: LuciqErrorBoundaryState = {
+    error: null,
+    componentStack: null,
+  };
+
+  static getDerivedStateFromError(error: Error): Partial<LuciqErrorBoundaryState> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    const componentStack = errorInfo.componentStack ?? null;
+    this.setState({ componentStack });
+
+    try {
+      const { nonFatalOptions, showBugReporting, onError } = this.props;
+
+      // Attach the React component stack as context on the non-fatal report.
+      const userAttributes = {
+        ...nonFatalOptions?.userAttributes,
+        ...(componentStack ? { componentStack } : {}),
+      };
+
+      CrashReporting.reportError(error, { ...nonFatalOptions, userAttributes });
+
+      if (showBugReporting) {
+        BugReporting.show(ReportType.bug, [InvocationOption.emailFieldOptional]);
+      }
+
+      onError?.(error, componentStack);
+    } catch (reportingError) {
+      Logger.error('[LuciqErrorBoundary] Failed to report render error:', reportingError);
+    }
+  }
+
+  resetError = () => {
+    this.setState({ error: null, componentStack: null });
+  };
+
+  render() {
+    const { error, componentStack } = this.state;
+
+    if (error) {
+      const { FallbackComponent } = this.props;
+
+      if (FallbackComponent) {
+        return (
+          <FallbackComponent
+            error={error}
+            componentStack={componentStack}
+            resetError={this.resetError}
+          />
+        );
+      }
+
+      return (
+        <View style={styles.container}>
+          <Text style={styles.title}>Something went wrong.</Text>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,4 +49,11 @@ export type {
 export { LuciqCaptureScreenLoading } from './components/LuciqCaptureScreenLoading';
 export type { LuciqScreenLoadingProps } from './components/LuciqCaptureScreenLoading';
 
+// Error Boundary Component
+export { LuciqErrorBoundary } from './components/LuciqErrorBoundary';
+export type {
+  LuciqErrorBoundaryProps,
+  LuciqErrorBoundaryFallbackProps,
+} from './components/LuciqErrorBoundary';
+
 export default Luciq;

--- a/test/components/LuciqErrorBoundary.spec.tsx
+++ b/test/components/LuciqErrorBoundary.spec.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+
+import * as BugReporting from '../../src/modules/BugReporting';
+import * as CrashReporting from '../../src/modules/CrashReporting';
+import { LuciqErrorBoundary } from '../../src/components/LuciqErrorBoundary';
+import { InvocationOption, ReportType } from '../../src/utils/Enums';
+import type { LuciqErrorBoundaryFallbackProps } from '../../src/components/LuciqErrorBoundary';
+
+jest.mock('../../src/modules/CrashReporting');
+jest.mock('../../src/modules/BugReporting');
+jest.mock('../../src/utils/logger', () => ({
+  Logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockReportError = CrashReporting.reportError as jest.Mock;
+const mockShow = BugReporting.show as jest.Mock;
+
+const Boom = ({ message = 'render failure' }: { message?: string }) => {
+  throw new Error(message);
+};
+
+const Safe = () => <Text>safe</Text>;
+
+describe('LuciqErrorBoundary', () => {
+  const originalConsoleError = console.error;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // React logs caught errors to console.error; silence to keep test output clean.
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('renders children when there is no error', () => {
+    render(
+      <LuciqErrorBoundary>
+        <Safe />
+      </LuciqErrorBoundary>,
+    );
+
+    expect(screen.getByText('safe')).toBeTruthy();
+    expect(mockReportError).not.toBeCalled();
+  });
+
+  it('reports caught render errors to CrashReporting with the component stack', () => {
+    render(
+      <LuciqErrorBoundary>
+        <Boom message="kaboom" />
+      </LuciqErrorBoundary>,
+    );
+
+    expect(mockReportError).toBeCalledTimes(1);
+    const [error, options] = mockReportError.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('kaboom');
+    expect(typeof options.userAttributes.componentStack).toBe('string');
+  });
+
+  it('renders the default fallback UI on error', () => {
+    render(
+      <LuciqErrorBoundary>
+        <Boom />
+      </LuciqErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong.')).toBeTruthy();
+  });
+
+  it('renders a custom FallbackComponent with error and resetError', () => {
+    const Fallback = ({ error, resetError }: LuciqErrorBoundaryFallbackProps) => (
+      <>
+        <Text>custom: {error.message}</Text>
+        <Text onPress={resetError}>reset</Text>
+      </>
+    );
+
+    render(
+      <LuciqErrorBoundary FallbackComponent={Fallback}>
+        <Boom message="custom-error" />
+      </LuciqErrorBoundary>,
+    );
+
+    expect(screen.getByText('custom: custom-error')).toBeTruthy();
+  });
+
+  it('shows the bug reporting UI when showBugReporting is true', () => {
+    render(
+      <LuciqErrorBoundary showBugReporting>
+        <Boom />
+      </LuciqErrorBoundary>,
+    );
+
+    expect(mockShow).toBeCalledTimes(1);
+    expect(mockShow).toBeCalledWith(ReportType.bug, [InvocationOption.emailFieldOptional]);
+  });
+
+  it('does not show the bug reporting UI by default', () => {
+    render(
+      <LuciqErrorBoundary>
+        <Boom />
+      </LuciqErrorBoundary>,
+    );
+
+    expect(mockShow).not.toBeCalled();
+  });
+
+  it('invokes the onError callback with the error and component stack', () => {
+    const onError = jest.fn();
+
+    render(
+      <LuciqErrorBoundary onError={onError}>
+        <Boom message="cb" />
+      </LuciqErrorBoundary>,
+    );
+
+    expect(onError).toBeCalledTimes(1);
+    expect(onError.mock.calls[0][0].message).toBe('cb');
+    expect(typeof onError.mock.calls[0][1]).toBe('string');
+  });
+
+  it('merges nonFatalOptions while attaching the component stack', () => {
+    render(
+      <LuciqErrorBoundary nonFatalOptions={{ fingerprint: 'fp', userAttributes: { foo: 'bar' } }}>
+        <Boom />
+      </LuciqErrorBoundary>,
+    );
+
+    const [, options] = mockReportError.mock.calls[0];
+    expect(options.fingerprint).toBe('fp');
+    expect(options.userAttributes.foo).toBe('bar');
+    expect(typeof options.userAttributes.componentStack).toBe('string');
+  });
+
+  it('recovers and renders children after resetError is called', () => {
+    let shouldThrow = true;
+    const Conditional = () => {
+      if (shouldThrow) {
+        throw new Error('once');
+      }
+      return <Text>recovered</Text>;
+    };
+
+    const Fallback = ({ resetError }: LuciqErrorBoundaryFallbackProps) => (
+      <Text onPress={resetError}>reset</Text>
+    );
+
+    render(
+      <LuciqErrorBoundary FallbackComponent={Fallback}>
+        <Conditional />
+      </LuciqErrorBoundary>,
+    );
+
+    expect(screen.getByText('reset')).toBeTruthy();
+
+    shouldThrow = false;
+    fireEvent.press(screen.getByText('reset'));
+
+    expect(screen.getByText('recovered')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description of the change

Adds a built-in `LuciqErrorBoundary` React component that catches rendering
errors in its child tree, reports them to Luciq as non-fatal crashes, and
renders a fallback UI.

Behavior:
- `componentDidCatch` reports the error via `CrashReporting.reportError`.
- The React component stack is attached as a `componentStack` user attribute
  on the report (merged with any caller-supplied `nonFatalOptions`).
- Accepts a `FallbackComponent` prop for custom error UI; otherwise renders a
  default "Something went wrong." view.
- `showBugReporting` prop (default `false`) optionally triggers the bug
  reporting UI on a render error.
- Exposes an `onError` callback and a `resetError` recovery handler.
- All reporting is wrapped in try/catch so the boundary never crashes the host app.

Component and types are exported from `src/index.ts`. JS-only change; reuses the
existing CrashReporting/BugReporting native bridges.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://instabug.atlassian.net/browse/MOB-22462

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
