### PR TITLE
feat: support user event parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased](https://github.com/luciqai/luciq-reactnative-sdk/compare/v19.8.0...dev)
+
+### Added
+
+- Add support for logging user events with key-value parameters using `UserEventParam`. ([#64](https://github.com/luciqai/luciq-reactnative-sdk/pull/64))
+
 ## [19.8.0](https://github.com/luciqai/luciq-reactnative-sdk/compare/v19.8.0...19.7.0)
 
 ### Added

--- a/android/src/main/java/ai/luciq/reactlibrary/RNLuciqReactnativeModule.java
+++ b/android/src/main/java/ai/luciq/reactlibrary/RNLuciqReactnativeModule.java
@@ -22,6 +22,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -68,6 +69,7 @@ import ai.luciq.library.model.LuciqTheme;
 import ai.luciq.library.model.NetworkLog;
 import ai.luciq.library.model.Report;
 import ai.luciq.library.ui.onboarding.WelcomeMessage;
+import ai.luciq.library.user.UserEventParam;
 import ai.luciq.reactlibrary.utils.ArrayUtil;
 import ai.luciq.reactlibrary.utils.EventEmitterModule;
 import ai.luciq.reactlibrary.utils.LuciqRNDebugTags;
@@ -708,20 +710,56 @@ public class RNLuciqReactnativeModule extends EventEmitterModule {
      * Logged user events are going to be sent with each report, as well as at the end of a session.
      *
      * @param name Event name.
+     * @param parameters User event parameters.
      */
     @ReactMethod
-    public void logUserEvent(final String name) {
+    public void logUserEvent(final String name, @Nullable final ReadableArray parameters) {
         MainThreadHandler.runOnMainThread(new Runnable() {
             @Override
             public void run() {
-                LuciqRNLogger.d(LuciqRNDebugTags.CORE, "[logUserEvent] called nameLen=" + (name == null ? 0 : name.length()) + ", present=" + (name != null));
+                LuciqRNLogger.d(LuciqRNDebugTags.CORE, "[logUserEvent] called nameLen=" + (name == null ? 0 : name.length()) + ", present=" + (name != null) + ", parametersCount=" + (parameters == null ? 0 : parameters.size()));
                 try {
-                    Luciq.logUserEvent(name);
+                    UserEventParam[] userEventParams = convertReadableArrayToUserEventParams(parameters);
+                    if (userEventParams.length == 0) {
+                        Luciq.logUserEvent(name);
+                    } else {
+                        Luciq.logUserEvent(name, userEventParams);
+                    }
                 } catch (java.lang.Exception exception) {
                     LuciqRNLogger.e(LuciqRNDebugTags.CORE, "[logUserEvent] failed", exception);
                 }
             }
         });
+    }
+
+    private UserEventParam[] convertReadableArrayToUserEventParams(@Nullable ReadableArray parameters) {
+        if (parameters == null || parameters.size() == 0) {
+            return new UserEventParam[0];
+        }
+
+        List<UserEventParam> userEventParams = new ArrayList<>();
+        for (int i = 0; i < parameters.size(); i++) {
+            if (parameters.isNull(i) || parameters.getType(i) != ReadableType.Map) {
+                continue;
+            }
+            ReadableMap parameter = parameters.getMap(i);
+            String key = getUserEventParamString(parameter, "key");
+            String value = getUserEventParamString(parameter, "value");
+            if (key == null || value == null) {
+                continue;
+            }
+            userEventParams.add(new UserEventParam(key, value));
+        }
+
+        return userEventParams.toArray(new UserEventParam[0]);
+    }
+
+    @Nullable
+    private String getUserEventParamString(ReadableMap parameter, String field) {
+        if (!parameter.hasKey(field) || parameter.isNull(field) || parameter.getType(field) != ReadableType.String) {
+            return null;
+        }
+        return parameter.getString(field);
     }
 
     /**

--- a/android/src/test/java/ai/luciq/reactlibrary/RNLuciqReactnativeModuleTest.java
+++ b/android/src/test/java/ai/luciq/reactlibrary/RNLuciqReactnativeModuleTest.java
@@ -25,6 +25,7 @@ import ai.luciq.library.featuresflags.model.LuciqFeatureFlag;
 import ai.luciq.library.featuresflags.model.LuciqFeatureFlag;
 import ai.luciq.library.internal.module.LuciqLocale;
 import ai.luciq.library.ui.onboarding.WelcomeMessage;
+import ai.luciq.library.user.UserEventParam;
 import ai.luciq.library.util.overairversion.OverAirVersionType;
 import ai.luciq.reactlibrary.utils.MainThreadHandler;
 import ai.luciq.library.MaskingType;
@@ -276,10 +277,28 @@ public class RNLuciqReactnativeModuleTest {
 
         String eventName = "click";
         // when
-        rnModule.logUserEvent(eventName);
+        rnModule.logUserEvent(eventName, null);
         // then
         verify(Luciq.class,times(1));
         Luciq.logUserEvent(eventName);
+    }
+
+    @Test
+    public void given$logUserEventWithParameters_whenQuery_thenShouldCallNativeApi() {
+        // given
+
+        String eventName = "Completed Purchase";
+        JavaOnlyArray parameters = new JavaOnlyArray();
+        JavaOnlyMap itemParameter = new JavaOnlyMap();
+        itemParameter.putString("key", "item");
+        itemParameter.putString("value", "Premium Plan");
+        parameters.pushMap(itemParameter);
+
+        // when
+        rnModule.logUserEvent(eventName, parameters);
+        // then
+        verify(Luciq.class,times(1));
+        Luciq.logUserEvent(Matchers.eq(eventName), Matchers.<UserEventParam[]>any());
     }
 
     @Test

--- a/examples/default/ios/LuciqTests/LuciqSampleTests.m
+++ b/examples/default/ios/LuciqTests/LuciqSampleTests.m
@@ -248,8 +248,18 @@
   NSString *name = @"event name";
 
   OCMStub([mock logUserEventWithName:name]);
-  [self.luciqBridge logUserEvent:name];
+  [self.luciqBridge logUserEvent:name parameters:@[]];
   OCMVerify([mock logUserEventWithName:name]);
+}
+
+- (void)testLogUserEventWithParameters {
+  id mock = OCMClassMock([Luciq class]);
+  NSString *name = @"event name";
+  NSArray *parameters = @[@{@"key": @"item", @"value": @"Premium Plan"}];
+
+  OCMStub([mock logUserEventWithName:name parameters:[OCMArg any]]);
+  [self.luciqBridge logUserEvent:name parameters:parameters];
+  OCMVerify([mock logUserEventWithName:name parameters:[OCMArg any]]);
 }
 
 - (void)testSetReproStepsConfig {

--- a/examples/default/src/screens/settings/SettingsScreen.tsx
+++ b/examples/default/src/screens/settings/SettingsScreen.tsx
@@ -7,6 +7,7 @@ import Luciq, {
   Locale,
   WelcomeMessageMode,
   ReproStepsMode,
+  UserEventParam,
 } from '@luciq/react-native';
 import { InputGroup, InputLeftAddon, useToast, VStack, Button } from 'native-base';
 
@@ -32,6 +33,9 @@ export const SettingsScreen: React.FC<NativeStackScreenProps<HomeStackParamList,
   const [userAttributeValue, setUserAttributeValue] = useState('');
   const [userData, setUserData] = useState('');
   const [userEvent, setUserEvent] = useState('');
+  const [userEventParams, setUserEventParams] = useState<Array<{ key: string; value: string }>>([
+    { key: '', value: '' },
+  ]);
   const [tag, setTag] = useState('');
   const [luciqLogLevel, setLuciqLogLevel] = useState<
     'verbose' | 'debug' | 'info' | 'warn' | 'error'
@@ -71,9 +75,17 @@ export const SettingsScreen: React.FC<NativeStackScreenProps<HomeStackParamList,
   };
   const validateUserEventForm = () => {
     const errors: any = {};
-    if (userData.length === 0) {
+    if (userEvent.length === 0) {
       errors.userEventValue = 'Value is required';
     }
+    userEventParams.forEach((param, index) => {
+      if (param.key.length > 0 && param.value.length === 0) {
+        errors[`userEventParamValue_${index}`] = 'Value is required';
+      }
+      if (param.value.length > 0 && param.key.length === 0) {
+        errors[`userEventParamKey_${index}`] = 'Key is required';
+      }
+    });
     setUserEventFormError(errors);
     return Object.keys(errors).length === 0;
   };
@@ -136,12 +148,27 @@ export const SettingsScreen: React.FC<NativeStackScreenProps<HomeStackParamList,
   };
   const saveUserEvent = () => {
     if (validateUserEventForm()) {
-      Luciq.logUserEvent(userEvent);
+      const parameters = userEventParams
+        .filter((param) => param.key.length > 0)
+        .map((param) => new UserEventParam(param.key, param.value));
+      Luciq.logUserEvent(userEvent, parameters);
       toast.show({
         description: 'User Event added successfully',
       });
-      setUserData('');
+      setUserEvent('');
+      setUserEventParams([{ key: '', value: '' }]);
     }
+  };
+  const updateUserEventParam = (index: number, field: 'key' | 'value', text: string) => {
+    setUserEventParams((params) =>
+      params.map((param, i) => (i === index ? { ...param, [field]: text } : param)),
+    );
+  };
+  const addUserEventParam = () => {
+    setUserEventParams((params) => [...params, { key: '', value: '' }]);
+  };
+  const removeUserEventParam = (index: number) => {
+    setUserEventParams((params) => params.filter((_, i) => i !== index));
   };
   const saveTag = () => {
     if (validateTagForm()) {
@@ -450,8 +477,37 @@ export const SettingsScreen: React.FC<NativeStackScreenProps<HomeStackParamList,
                 />
               </View>
             </View>
+            {userEventParams.map((param, index) => (
+              <View style={styles.formContainer} key={`user-event-param-${index}`}>
+                <View style={styles.inputWrapper}>
+                  <InputField
+                    placeholder="Parameter key"
+                    onChangeText={(key) => updateUserEventParam(index, 'key', key)}
+                    value={param.key}
+                    errorText={userEventFormError[`userEventParamKey_${index}`]}
+                  />
+                </View>
+                <View style={styles.inputWrapper}>
+                  <InputField
+                    placeholder="Parameter value"
+                    onChangeText={(value) => updateUserEventParam(index, 'value', value)}
+                    value={param.value}
+                    errorText={userEventFormError[`userEventParamValue_${index}`]}
+                  />
+                </View>
+                {userEventParams.length > 1 && (
+                  <Button colorScheme="danger" onPress={() => removeUserEventParam(index)}>
+                    -
+                  </Button>
+                )}
+              </View>
+            ))}
 
-            <Button mt="4" onPress={saveUserEvent}>
+            <Button mt="4" variant="outline" onPress={addUserEventParam}>
+              Add parameter
+            </Button>
+
+            <Button mt="2" onPress={saveUserEvent}>
               Save user event
             </Button>
           </VStack>

--- a/ios/RNLuciq/LuciqReactBridge.h
+++ b/ios/RNLuciq/LuciqReactBridge.h
@@ -60,7 +60,7 @@
 
 - (void)logOut;
 
-- (void)logUserEvent:(NSString *)name;
+- (void)logUserEvent:(NSString *)name parameters:(NSArray *)parameters;
 
 - (void)logVerbose:(NSString *)log;
 

--- a/ios/RNLuciq/LuciqReactBridge.m
+++ b/ios/RNLuciq/LuciqReactBridge.m
@@ -402,9 +402,35 @@ RCT_EXPORT_METHOD(clearAllUserAttributes) {
     }
 }
 
-RCT_EXPORT_METHOD(logUserEvent:(NSString *)name) {
-    [LuciqRNLogger d:[LuciqRNDebugTags core] format:@"[logUserEvent] called nameLength=%lu present=%@", (unsigned long)name.length, (name != nil ? @"YES" : @"NO")];
-    [Luciq logUserEventWithName:name];
+RCT_EXPORT_METHOD(logUserEvent:(NSString *)name parameters:(NSArray *)parameters) {
+    [LuciqRNLogger d:[LuciqRNDebugTags core] format:@"[logUserEvent] called nameLength=%lu present=%@ parametersCount=%lu", (unsigned long)name.length, (name != nil ? @"YES" : @"NO"), (unsigned long)parameters.count];
+    NSArray<LCQUserEventParam *> *userEventParams = [self userEventParamsFromArray:parameters];
+    if (userEventParams.count == 0) {
+        [Luciq logUserEventWithName:name];
+    } else {
+        [Luciq logUserEventWithName:name parameters:userEventParams];
+    }
+}
+
+- (NSArray<LCQUserEventParam *> *)userEventParamsFromArray:(NSArray *)parameters {
+    if (parameters.count == 0) {
+        return @[];
+    }
+
+    NSMutableArray<LCQUserEventParam *> *userEventParams = [NSMutableArray arrayWithCapacity:parameters.count];
+    for (NSDictionary *parameter in parameters) {
+        if (![parameter isKindOfClass:[NSDictionary class]]) {
+            continue;
+        }
+        NSString *key = parameter[@"key"];
+        NSString *value = parameter[@"value"];
+        if (![key isKindOfClass:[NSString class]] || ![value isKindOfClass:[NSString class]]) {
+            continue;
+        }
+        [userEventParams addObject:[[LCQUserEventParam alloc] initWithKey:key value:value]];
+    }
+
+    return userEventParams;
 }
 
 RCT_EXPORT_METHOD(setLCQLogPrintsToConsole:(BOOL) printsToConsole) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { LuciqConfig } from './models/LuciqConfig';
 import Report from './models/Report';
 import type { ThemeConfig } from './models/ThemeConfig';
 import { CustomSpan } from './models/CustomSpan';
+import { UserEventParam } from './models/UserEventParam';
 // Modules
 import * as APM from './modules/APM';
 import * as BugReporting from './modules/BugReporting';
@@ -25,6 +26,7 @@ export * from './utils/Enums';
 export {
   Report,
   CustomSpan,
+  UserEventParam,
   APM,
   BugReporting,
   CrashReporting,

--- a/src/models/UserEventParam.ts
+++ b/src/models/UserEventParam.ts
@@ -1,0 +1,12 @@
+/**
+ * A key-value parameter that can be attached to a user event.
+ */
+export class UserEventParam {
+  key: string;
+  value: string;
+
+  constructor(key: string, value: string) {
+    this.key = key;
+    this.value = value;
+  }
+}

--- a/src/modules/Luciq.ts
+++ b/src/modules/Luciq.ts
@@ -40,6 +40,7 @@ import { Logger } from '../utils/logger';
 import { LuciqDebugTags } from '../constants/DebugTags';
 import type { OverAirUpdate } from '../models/OverAirUpdate';
 import type { ThemeConfig } from '../models/ThemeConfig';
+import type { UserEventParam } from '../models/UserEventParam';
 
 let _currentScreen: string | null = null;
 let _lastScreen: string | null = null;
@@ -585,10 +586,14 @@ export const logOut = () => {
  * Logs a user event that happens through the lifecycle of the application.
  * Logged user events are going to be sent with each report, as well as at the end of a session.
  * @param name Event name.
+ * @param parameters Optional key-value parameters to attach to the event.
  */
-export const logUserEvent = (name: string) => {
-  Logger.debug(LuciqDebugTags.CORE, 'logUserEvent', { nameLength: name?.length ?? 0 });
-  NativeLuciq.logUserEvent(name);
+export const logUserEvent = (name: string, parameters: UserEventParam[] = []) => {
+  Logger.debug(LuciqDebugTags.CORE, 'logUserEvent', {
+    nameLength: name?.length ?? 0,
+    parametersCount: parameters?.length ?? 0,
+  });
+  NativeLuciq.logUserEvent(name, parameters ?? []);
 };
 
 /**

--- a/src/native/NativeLuciq.ts
+++ b/src/native/NativeLuciq.ts
@@ -16,6 +16,7 @@ import type { W3cExternalTraceAttributes } from '../models/W3cExternalTraceAttri
 import { NativeModules } from './NativePackage';
 import type { OverAirUpdate } from '../models/OverAirUpdate';
 import type { ThemeConfig } from '../models/ThemeConfig';
+import type { UserEventParam } from '../models/UserEventParam';
 
 export interface LuciqNativeModule extends NativeModule {
   getConstants(): NativeConstants;
@@ -108,7 +109,7 @@ export interface LuciqNativeModule extends NativeModule {
   // User APIs //
   identifyUser(email: string, name: string, id?: string): void;
   logOut(): void;
-  logUserEvent(name: string): void;
+  logUserEvent(name: string, parameters: UserEventParam[]): void;
   setUserData(data: string): void;
 
   // User Attributes APIs //

--- a/test/modules/Luciq.spec.ts
+++ b/test/modules/Luciq.spec.ts
@@ -20,6 +20,7 @@ import {
   OverAirUpdateServices,
   ReproStepsMode,
   StringKey,
+  UserEventParam,
   WelcomeMessageMode,
 } from '../../src';
 import type { LuciqConfig } from '../../src';
@@ -635,7 +636,20 @@ describe('Luciq Module', () => {
     Luciq.logUserEvent(event);
 
     expect(NativeLuciq.logUserEvent).toBeCalledTimes(1);
-    expect(NativeLuciq.logUserEvent).toBeCalledWith(event);
+    expect(NativeLuciq.logUserEvent).toBeCalledWith(event, []);
+  });
+
+  it('should call the native method logUserEvent with parameters', () => {
+    const event = 'Completed Purchase';
+    const parameters = [
+      new UserEventParam('item', 'Premium Plan'),
+      new UserEventParam('currency', 'USD'),
+    ];
+
+    Luciq.logUserEvent(event, parameters);
+
+    expect(NativeLuciq.logUserEvent).toBeCalledTimes(1);
+    expect(NativeLuciq.logUserEvent).toBeCalledWith(event, parameters);
   });
 
   it('should call the native method logVerbose', () => {


### PR DESCRIPTION
## Description of the change

Adds support for attaching key-value parameters to user event logs.

- New `UserEventParam` model (`{ key, value }`) exported from the SDK entrypoint.
- `Luciq.logUserEvent(name)` is overloaded to `Luciq.logUserEvent(name, parameters?)`, accepting a `UserEventParam[]`. Backward compatible: existing single-argument calls keep working and fall back to the parameterless native API when no params are passed.
- Native bridges marshal the parameters to the platform SDKs:
  - iOS: builds `LCQUserEventParam[]` and calls `logUserEventWithName:parameters:`.
  - Android: converts the `ReadableArray` to `UserEventParam[]` and calls `Luciq.logUserEvent(name, params)`.
- Both bridges null/type-guard each entry and skip structurally invalid items; spec-level validation (trim, empty, length limits, max 15, duplicate keys) is owned by the native core SDKs.
- Example app: the User Event form now supports adding/removing multiple parameter rows for testing the multi-param path.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> [Issue links go here](https://instabug.atlassian.net/browse/MOB-22690)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
